### PR TITLE
glyphTransformFn must be used to build fonts

### DIFF
--- a/src/glyphs2svgFont.js
+++ b/src/glyphs2svgFont.js
@@ -3,7 +3,14 @@ var SVGIcons2SVGFontStream = require('svgicons2svgfont');
 
 module.exports = function svgIcons2svgFontFn(glyphDatas, options) {
     let svg = '';
-
+    if (typeof options.glyphTransformFn === 'function') {
+        glyphDatas.map(glyphData => {
+            options.glyphTransformFn(
+                glyphData.metadata
+            );
+            return glyphData.metadata;
+        })
+    }
     return new Promise((resolve, reject) => {
         const fontStream = new SVGIcons2SVGFontStream({
             ascent: options.ascent,


### PR DESCRIPTION
When the `option.glyphTransformFn` is setted,
the transformation must apply for css and font build.

Only the css use this option.
This merge request add the transformation for building font.

As an exemple, in my case I have in the webpack config :


```
    const glyphsConfig = {
       "arrow-down": "0xf101",
       "check": "0xf102",
    [...]
   }

    glyphTransformFn: (glyphData) => {
      if (glyphsConfig[glyphData.name]) {
        glyphData.unicode = [String.fromCharCode(glyphsConfig[glyphData.name])]
      }
      return glyphData;
    }

```

The CSS handle this as espected


```
...
.icon .prefix-arrow-down-r::before {
    content: "\ea01";
}
.icon .prefix-arrow-down::before {
    content: "\f101";  // <----- HERE !
}
.icon .prefix-arrow-left-r::before {
    content: "\ea03";
}
...

```

But the font is wrong (SVG to be readable by humain)

```
...
    <glyph glyph-name="arrow-down-r"
      unicode="&#xEA01;"
      horiz-adv-x="1000" d="..." />
    <glyph glyph-name="arrow-down"
      unicode="&#xEA02;"   // <- ERROR HERE !
      horiz-adv-x="1000" d="..." />
    <glyph glyph-name="arrow-left-r"
      unicode="&#xEA03;"
   ...

```

This MR apply glyphTransformFn for building fonts.